### PR TITLE
98_card_create_reload / カード作成時リロード処理設定

### DIFF
--- a/app/javascript/components/CardAdd.vue
+++ b/app/javascript/components/CardAdd.vue
@@ -54,6 +54,7 @@ export default {
     addCardToList: function() {
       this.$store.dispatch('cards/createCardAction', { body: this.body, list_id: this.list_id })
       this.body = ''
+      this.$router.go({path: this.$router.currentRoute.path, force: true})
     }
   }
 }

--- a/app/javascript/components/List.vue
+++ b/app/javascript/components/List.vue
@@ -65,10 +65,10 @@ export default {
     }
   },
   props: {
-    id: {
-      type: Number,
-      required: true
-    },
+    // id: {
+    //   type: Number,
+    //   required: true
+    // },
     title: {
       type: String,
       required: true


### PR DESCRIPTION
暫定対応として
カード作成アクション発火時にリロードするようにした